### PR TITLE
Bugfix in VectorLeaf.Apply when TValue and TOut are different

### DIFF
--- a/Solid/Solid/Implementation/TrieVector/VectorLeaf.cs
+++ b/Solid/Solid/Implementation/TrieVector/VectorLeaf.cs
@@ -97,7 +97,6 @@ namespace Solid
 			public override TrieVector<TOut>.VectorNode Apply<TOut>(Func<TValue, TOut> transform)
 			{
 				var newArr = new TOut[Arr.Length];
-				Arr.CopyTo(newArr, 0);
 				for (var i = 0; i < newArr.Length; i++)
 				{
 					newArr[i] = transform(Arr[i]);


### PR DESCRIPTION
Removed just one unneeded line that only works when the two types are the same, but fails otherwise
