### PR TITLE
Add some generative FsCheck tests for ImmMap

### DIFF
--- a/Imms/ExtraFunctional/ExtraFunctional/Option.fs
+++ b/Imms/ExtraFunctional/ExtraFunctional/Option.fs
@@ -2,7 +2,7 @@
 module Option = 
     let orValue (v : 'v) = function Some u -> u | None -> v
     let orMaybe (v : 'v option) = function Some u -> Some u | None -> v
-    let asNull = Option.toObj
+    let asNull (v : 'v option) = if v.IsNone then null else v.Value
     let cast<'a,'b> (opt : 'a option) : 'b option = opt |> Option.map (fun a -> a :> obj :?> 'b)
     
 [<AutoOpen>]

--- a/Imms/Imms.FSharp/Imms.FSharp.fsproj
+++ b/Imms/Imms.FSharp/Imms.FSharp.fsproj
@@ -85,10 +85,6 @@
     <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core">
-      <HintPath>..\..\..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Imms/Imms.Tests.Integrity/App.config
+++ b/Imms/Imms.Tests.Integrity/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="2.0.0.0" newVersion="4.3.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0" />
         <bindingRedirect oldVersion="2.3.5.0" newVersion="4.3.0.0" />
         <bindingRedirect oldVersion="4.0.0.0" newVersion="4.3.0.0" />
       </dependentAssembly>

--- a/Imms/Imms.Tests.Integrity/Imms.Tests.Integrity.fsproj
+++ b/Imms/Imms.Tests.Integrity/Imms.Tests.Integrity.fsproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -16,6 +17,8 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,8 +45,12 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core">
-      <HintPath>..\..\..\packages\FSharp.Core.4.0.0.1\lib\net40\FSharp.Core.dll</HintPath>
+    <Reference Include="FsCheck">
+      <HintPath>..\packages\FsCheck.2.6.0\lib\net45\FsCheck.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsCheck.Xunit">
+      <HintPath>..\packages\FsCheck.Xunit.2.6.0\lib\net45\FsCheck.Xunit.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
@@ -54,6 +61,18 @@
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\portable-net45+win8+wp8+wpa81\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Definitions.fs" />
@@ -112,6 +131,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Imms/Imms.Tests.Integrity/packages.config
+++ b/Imms/Imms.Tests.Integrity/packages.config
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FsCheck" version="2.6.0" targetFramework="net451" />
+  <package id="FsCheck.Xunit" version="2.6.0" targetFramework="net451" />
   <package id="FSharp.Core" version="4.0.0.1" targetFramework="net451" />
   <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net451" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Hey, not sure if this is useful, or if you already got this covered with other tests, but I made a function to test persistent maps for another project so I thought I'd try on ImmMap too.

It generates a random FSharp.Core.Map, then a random set of actions to do on it (Add | Remove), maintains both an ImmMap and FSharp Map, and then after all the actions are completed, checks that all the intermediate ImmMaps and FSharp Maps are equal.

You can see the input it generates if you change `Property` to `Property(Verbose=True)` and then click output in the visual studio test runner. Both `ImmMap` and `ImmSortedMap` pass this test.

I had to add some dependencies to the test project, not sure if that is an issue. I also had to drop some references to FSharp.Core to get things to compile on my machine.

If you are open to this kind of thing, I can make some tests for ImmList too.
